### PR TITLE
Converted list of parameters to single instance, fixes #3

### DIFF
--- a/src/main/java/com/g4s8/mime/MimeType.java
+++ b/src/main/java/com/g4s8/mime/MimeType.java
@@ -17,7 +17,6 @@
 package com.g4s8.mime;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -48,5 +47,5 @@ public interface MimeType {
      * @return Parameter map
      * @throws IOException If failed to read
      */
-    Map<String, List<String>> params() throws IOException;
+    Map<String, String> params() throws IOException;
 }

--- a/src/main/java/com/g4s8/mime/MimeTypeOf.java
+++ b/src/main/java/com/g4s8/mime/MimeTypeOf.java
@@ -18,8 +18,6 @@ package com.g4s8.mime;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -84,20 +82,22 @@ public final class MimeTypeOf implements MimeType {
 
     @Override
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    public Map<String, List<String>> params() throws IOException {
+    public Map<String, String> params() throws IOException {
         final Matcher match = this.matcher();
         final Matcher param = MimeTypeOf.PTN_PARAM.matcher(this.src);
-        final Map<String, List<String>> map = new HashMap<>(1);
+        final Map<String, String> map = new HashMap<>(1);
         for (int id = match.end(); id < this.src.length(); id = param.end()) {
             param.region(id, this.src.length());
             if (!param.lookingAt()) {
                 throw new IOException("Invalid mime-type params format");
             }
             final String name = param.group(1);
-            if (!map.containsKey(name)) {
-                map.put(name, new LinkedList<String>());
+            if (map.containsKey(name)) {
+                throw new IOException(
+                    String.format("Parameter %s may only exist once.", name)
+                );
             }
-            map.get(name).add(MimeTypeOf.paramValue(param));
+            map.put(name, MimeTypeOf.paramValue(param));
         }
         return map;
     }

--- a/src/main/java/com/g4s8/mime/MimeTypeSmart.java
+++ b/src/main/java/com/g4s8/mime/MimeTypeSmart.java
@@ -17,7 +17,6 @@
 package com.g4s8.mime;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -60,7 +59,7 @@ public final class MimeTypeSmart implements MimeType {
     }
 
     @Override
-    public Map<String, List<String>> params() throws IOException {
+    public Map<String, String> params() throws IOException {
         return this.orig.params();
     }
 
@@ -70,18 +69,15 @@ public final class MimeTypeSmart implements MimeType {
      * @throws IOException If not found or invalid.
      */
     public String charset() throws IOException {
-        final Map<String, List<String>> params = this.params();
+        final Map<String, String> params = this.params();
         if (!params.containsKey(MimeTypeSmart.PARAM_CHARSET)) {
             throw new IOException("Charset is not provided");
         }
-        final List<String> charsets = params.get(MimeTypeSmart.PARAM_CHARSET);
-        if (charsets.isEmpty()) {
-            throw new IOException("Empty charset param");
+        final String charset = params.get(MimeTypeSmart.PARAM_CHARSET);
+        if (charset == null || "".equals(charset)) {
+            throw new IOException("The charset parameter is not set");
         }
-        if (charsets.size() > 1) {
-            throw new IOException("More than one charset");
-        }
-        return charsets.get(0);
+        return charset;
     }
 
     @Override

--- a/src/test/java/com/g4s8/mime/MimeTypeOfTest.java
+++ b/src/test/java/com/g4s8/mime/MimeTypeOfTest.java
@@ -57,10 +57,15 @@ public final class MimeTypeOfTest {
             "Can't read params",
             new MimeTypeOf("multipart/byteranges; boundary=3d6b6a416f9b5")
                 .params()
-                .get("boundary")
-                .get(0),
+                .get("boundary"),
             Matchers.equalTo("3d6b6a416f9b5")
         );
+    }
+
+    @Test(expected = IOException.class)
+    public void sameParamTwice() throws IOException {
+        new MimeTypeOf("multipart/byteranges; a=1; a=1")
+            .params();
     }
 
     @Test

--- a/src/test/java/com/g4s8/mime/MimeTypeSmartTest.java
+++ b/src/test/java/com/g4s8/mime/MimeTypeSmartTest.java
@@ -42,6 +42,13 @@ public final class MimeTypeSmartTest {
         );
     }
 
+    @Test(expected = IOException.class)
+    public void testNoCharset() throws IOException {
+        new MimeTypeSmart(
+            new MimeTypeOf("text/html")
+        ).charset();
+    }
+
     @Test
     public void asString() {
         final String src = "application/octet-stream";


### PR DESCRIPTION
I converted the code so that a parameter can only exist once, otherwise an IllegalStateException is thrown. To be sure that it works, I created a negative test which triggers the exception and I extended the charset test to also include a negative test which triggers the IOException.

Compilation and unit tests were ok, Checkstyle bothered me with the line endings which should be corrected on commit - I'm using Windows :flushed: