### PR TITLE
feat: parse multiple types

### DIFF
--- a/src/main/java/wtf/g4s8/mime/MimeType.java
+++ b/src/main/java/wtf/g4s8/mime/MimeType.java
@@ -4,8 +4,11 @@
  */
 package wtf.g4s8.mime;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Media type (or MIME type).
@@ -45,6 +48,29 @@ public interface MimeType {
      */
     static MimeType of(final CharSequence src) {
         return new MimeTypeOfString(src);
+    }
+
+    /**
+     * Parse mime-type string containing multiple media types with qualifiers.
+     * <p>
+     * Multiple media types could be used in {@code Accept} headers.
+     * Mime types are ordered first by qualifier param {@code q} value, then by order
+     * of appearance in source string.
+     * </p>
+     * @param src Source string
+     * @return Ordered collection of mime types
+     * @since 2.1
+     */
+    static Collection<MimeType> parse(final CharSequence src) {
+        return Arrays.stream(src.toString().split(","))
+            .map(String::trim)
+            .map(MimeTypeOfString::new)
+            .sorted(
+                (left, right) -> Float.compare(
+                    right.param("q").map(Float::parseFloat).orElse(0F),
+                    left.param("q").map(Float::parseFloat).orElse(0F)
+                )
+            ).collect(Collectors.toList());
     }
 
     /**

--- a/src/test/java/wtf/g4s8/mime/MimeTypeTest.java
+++ b/src/test/java/wtf/g4s8/mime/MimeTypeTest.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2017-2021 Kirill Ch. <g4s8.public@gmail.com>
+ * https://github.com/g4s8/mime/LICENSE.txt
+ */
+package wtf.g4s8.mime;
+// // text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import wtf.g4s8.mime.test.HmMimeHasSubType;
+import wtf.g4s8.mime.test.HmMimeHasType;
+
+/**
+ * Test case for {@link MimeType}.
+ *
+ * @since 2.1
+ */
+final class MimeTypeTest {
+    @Test
+    void parseMultipleTypes() {
+        MatcherAssert.assertThat(
+            MimeType.parse("text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8"),
+            Matchers.contains(
+                Matchers.allOf(new HmMimeHasType("application"), new HmMimeHasSubType("xml")),
+                Matchers.allOf(new HmMimeHasType("*"), new HmMimeHasSubType("*")),
+                Matchers.allOf(new HmMimeHasType("text"), new HmMimeHasSubType("html")),
+                Matchers.allOf(new HmMimeHasType("application"), new HmMimeHasSubType("xhtml+xml"))
+            )
+        );
+    }
+}


### PR DESCRIPTION
Added `parse` method to parse string into collection
of `MimeType`s ordering by `q` (qualifier) parameter.